### PR TITLE
honor gdefault option

### DIFF
--- a/autoload/over/command_line/substitute.vim
+++ b/autoload/over/command_line/substitute.vim
@@ -147,7 +147,7 @@ function! s:substitute_preview(line)
 	else
 		let string = s:hl_mark_begin . '\0' . s:hl_mark_center . string . s:hl_mark_end
 	endif
-	let s:undo_flag = s:silent_substitute(range, pattern, string, 'g')
+	let s:undo_flag = s:silent_substitute(range, pattern, string, &gdefault ? '' : 'g')
 
 	let &l:concealcursor = "nvic"
 	let &l:conceallevel = 3


### PR DESCRIPTION
Plugin is not honor `&gdefault` option, so if it is set, you got opposite visual feedback, e.g., plugin shows that only one occurence in line will be replaced, however, actual replace modify all occurrences. If `&gdefault` is not set, it behaves in opposite way.

Proposed patch fixing this behavior.
