### PR TITLE
use current search pattern if no given

### DIFF
--- a/autoload/over/command_line/substitute.vim
+++ b/autoload/over/command_line/substitute.vim
@@ -130,7 +130,7 @@ function! s:substitute_preview(line)
 
 	let [range, pattern, string, flags] = result
 	if empty(pattern)
-		return
+		let pattern = @/
 	endif
 
 	if empty(string)


### PR DESCRIPTION
Another "epic" patch.

Use case:
1. highlight some word with `#` or `*`;
2. `:OverCommandLine`;
3. enter `%s//lala`;

All occurrences of selected word will be successfully replaced on `lala`, but there are will be no preview available.

Proposed patch will fix preview.
