### PR TITLE
keep @/, very magic, search in visual

### DIFF
--- a/autoload/over.vim
+++ b/autoload/over.vim
@@ -71,6 +71,9 @@ function! s:parse_substitute(word)
 	if type(result) == type(0) || empty(result)
 		return []
 	endif
+	if result[0] == '/' || result[0] == '?'
+		return []
+	endif
 	unlet result[1]
 	return result
 endfunction

--- a/autoload/over/command_line.vim
+++ b/autoload/over/command_line.vim
@@ -222,7 +222,17 @@ let s:module = {
 \	"name" : "HighlightVisualMode"
 \}
 
-function! s:module.on_enter(...)
+function! s:module.on_draw_pre(cmdline)
+    if exists("self.visual_highlighted")
+        return
+    endif
+
+    let self.visual_highlighted = 1
+
+    if a:cmdline.getline()[0:4] != "'<,'>"
+        return
+    endif
+
 	if &selection == "exclusive"
 		let pat = '\%''<\|\%>''<.*\%<''>'
 	else
@@ -232,8 +242,8 @@ function! s:module.on_enter(...)
 	call s:Highlight.highlight("visualmode", "Visual", pat, 0)
 endfunction
 
-
 function! s:module.on_leave(...)
+    unlet self.visual_highlighted
 	call s:Highlight.clear("visualmode")
 endfunction
 

--- a/autoload/over/command_line.vim
+++ b/autoload/over/command_line.vim
@@ -197,6 +197,10 @@ function! over#command_line#backward()
 endfunction
 
 
+function! over#command_line#bind_pattern_by_visual(pattern)
+    return '\%V' . a:pattern
+endfunction
+
 call over#command_line#substitute#load()
 call over#command_line#search#load()
 call over#command_line#global#load()

--- a/autoload/over/command_line/search.vim
+++ b/autoload/over/command_line/search.vim
@@ -13,15 +13,15 @@ endfunction
 
 
 function! s:search_hl_off()
-	if exists("s:search_id") && s:search_id != -1
+	if get(s:, "search_id", -1) != -1
 		call matchdelete(s:search_id)
 		unlet s:search_id
 	endif
-	if exists("s:current_search_id") && s:current_search_id != -1
+	if get(s:, "current_search_id", -1) != -1
 		call matchdelete(s:current_search_id)
 		unlet s:current_search_id
 	endif
-	if exists("s:cursor_search_id") && s:cursor_search_id != -1
+	if get(s:, "cursor_search_id", -1) != -1
 		call matchdelete(s:cursor_search_id)
 		unlet s:cursor_search_id
 	endif
@@ -68,9 +68,9 @@ function! s:main()
 		if g:over#command_line#search#enable_move_cursor
 			call setpos(".", s:old_pos)
 			if line =~ '^/.\+'
-				silent! call searchpos(s:pattern, "")
+				silent! call search(s:pattern, "")
 			else
-				silent! call searchpos(s:pattern, "b")
+				silent! call search(s:pattern, "b")
 			endif
 		endif
 	endif

--- a/autoload/over/command_line/search.vim
+++ b/autoload/over/command_line/search.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 let g:over#command_line#search#enable_incsearch = get(g:, "over#command_line#search#enable_incsearch", 1)
 let g:over#command_line#search#enable_move_cursor = get(g:, "over#command_line#search#enable_move_cursor", 0)
+let g:over#command_line#search#keep_search = get(g:, "over#command_line#search#keep_search", 1)
 
 
 function! over#command_line#search#load()
@@ -16,29 +17,60 @@ function! s:search_hl_off()
 		call matchdelete(s:search_id)
 		unlet s:search_id
 	endif
+	if exists("s:current_search_id") && s:current_search_id != -1
+		call matchdelete(s:current_search_id)
+		unlet s:current_search_id
+	endif
+	if exists("s:cursor_search_id") && s:cursor_search_id != -1
+		call matchdelete(s:cursor_search_id)
+		unlet s:cursor_search_id
+	endif
 endfunction
 
 
 function! s:search_hl_on(pattern)
 	call s:search_hl_off()
 	silent! let s:search_id = matchadd("IncSearch", a:pattern)
+	silent! let s:current_search_id = matchadd(
+		\ "Search",
+		\ '\%#' . a:pattern
+	\ )
+	silent! let s:cursor_search_id = matchadd("Cursor", '\%#')
 endfunction
 
 
 function! s:main()
 	call s:search_hl_off()
 	let line = over#command_line#backward()
+
+	let visual = 0
+	if line[0:4] == "'<,'>"
+		let visual = 1
+		let line = line[5:]
+	endif
+
 	if line =~ '^/.\+'
 \	|| line =~ '^?.\+'
-		let pattern = matchstr(line, '^\(/\|?\)\zs.\+')
+
+		let s:pattern = matchstr(line, '^\(/\|?\)\zs.\+')
+
+		if visual
+			let s:pattern = over#command_line#bind_pattern_by_visual(
+				\ s:pattern
+			\ )
+		endif
+
+		nohlsearch
+
 		if g:over#command_line#search#enable_incsearch
-			call s:search_hl_on((&ignorecase ? '\c' : "") . pattern)
+			call s:search_hl_on((&ignorecase ? '\c' : "") . s:pattern)
 		endif
 		if g:over#command_line#search#enable_move_cursor
+			call setpos(".", s:old_pos)
 			if line =~ '^/.\+'
-				silent! call search(pattern, "c")
+				silent! call searchpos(s:pattern, "")
 			else
-				silent! call search(pattern, "cb")
+				silent! call searchpos(s:pattern, "b")
 			endif
 		endif
 	endif
@@ -50,7 +82,8 @@ augroup over-cmdline-search
 	autocmd User OverCmdLineChar call s:main()
 	autocmd User OverCmdLineLeave call s:search_hl_off()
 	autocmd User OverCmdLineEnter let s:old_pos = getpos(".")
-	autocmd User OverCmdLineExecutePre call setpos(".", s:old_pos)
+	autocmd User OverCmdLineExecute if g:over#command_line#search#keep_search
+		\ | let @/ = s:pattern | endif
 augroup END
 
 

--- a/autoload/over/command_line/substitute.vim
+++ b/autoload/over/command_line/substitute.vim
@@ -105,7 +105,7 @@ endfunction
 
 
 function! s:undo()
-	if s:undo_flag
+	if exists('s:undo_flag') && s:undo_flag
 		call s:silent_undo()
 		let s:undo_flag = 0
 	endif
@@ -142,6 +142,7 @@ function! s:silent_substitute(range, pattern, string, flags)
 		let old_search = @/
 		let check = b:changedtick
 		silent execute printf('%ss/%s/%s/%s', a:range, a:pattern, a:string, flags)
+		nohlsearch
 		call histdel("search", -1)
 		let &l:modified = s:old_modified
 	catch /\v^Vim%(\(\a+\))=:(E121)|(E117)|(E110)|(E112)|(E113)|(E731)|(E475)|(E15)/
@@ -182,6 +183,12 @@ function! s:substitute_preview(line)
 		let pattern = @/
 	endif
 
+	if range == "'<,'>"
+		let pattern = over#command_line#bind_pattern_by_visual(
+			\ pattern
+		\ )
+	endif
+
 	if empty(string)
 		call s:matchadd(g:over#command_line#substitute#highlight_pattern, (&ignorecase ? '\c' : '') . pattern)
 		return
@@ -196,6 +203,7 @@ function! s:substitute_preview(line)
 	else
 		let string = s:hl_mark_begin . '\0' . s:hl_mark_center . string . s:hl_mark_end
 	endif
+
 	let s:undo_flag = s:silent_substitute(range, pattern, string, flags)
 
 	let &l:concealcursor = "nvic"

--- a/autoload/over/command_line/substitute.vim
+++ b/autoload/over/command_line/substitute.vim
@@ -105,7 +105,7 @@ endfunction
 
 
 function! s:undo()
-	if exists('s:undo_flag') && s:undo_flag
+	if get(s:, 'undo_flag', 0)
 		call s:silent_undo()
 		let s:undo_flag = 0
 	endif

--- a/doc/over.txt
+++ b/doc/over.txt
@@ -45,6 +45,10 @@ COMMANDS                                                   *over-commands*
   
   {input} pre-feed the command line with the given input.
 
+:'<,'>OverCommandLine /{pattern}
+:'<,'>OverCommandLine ?{pattern}
+  Same as above, but apply search only to visually selected range.
+
 :OverCommandLineNoremap {lhs} {rhs}		 *:OverCommandLineNoremap*
   It is the same as :OverCommandLine but with a specified key remap.
   {lhs} will be substitued by {rhs}.
@@ -124,6 +128,8 @@ Default: >
     \	"\r" : '\\r',
     \}
 <
+g:over#command_line#keep_search  	*g:over#command_line#keep_search*
+  Populate @/ after searching or substitute through OverCommandLine.
 
 
 ==============================================================================


### PR DESCRIPTION
Proposed pull request will do following things:
* `@/` will be filled with successfull search pattern in search/replace modes;
* option added that allows user to user `very magic` patterns (`\v`) without specifying it in the pattern, so autocompletion will work;
* **search and substitute modes can now highlight matches only in visual selection** (:+1: for highlighting visual selected text);
* while using vim-over for searching (`:OverCommandLine /`), match that will be used first highlighted in the same way as in https://github.com/dahu/SearchParty plugin;
* vim-over plays nice with https://github.com/dahu/SearchParty plugin.