### PR TITLE
Adds the option to replace the preview in place of the word instead of beside it

### DIFF
--- a/autoload/over/command_line.vim
+++ b/autoload/over/command_line.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 
 let g:over#command_line#enable_import_commandline_map = get(g:, "over#command_line#enable_import_commandline_map", 1)
+let g:over#command_line#substitute#replace_pattern_visually = get(g:, "over#command_line#substitute#replace_pattern_visually", 0)
 
 function! over#command_line#load()
 	" dummy

--- a/autoload/over/command_line/substitute.vim
+++ b/autoload/over/command_line/substitute.vim
@@ -194,7 +194,11 @@ function! s:substitute_preview(line)
 		let hl_submatch = printf('\\="%s" . submatch(0) . "%s" . (', s:hl_mark_begin, s:hl_mark_center)
 		let string = substitute(string, '^\\=\ze.\+', hl_submatch, "") . ') . "' . s:hl_mark_end . '"'
 	else
-		let string = s:hl_mark_begin . '\0' . s:hl_mark_center . string . s:hl_mark_end
+		if g:over#command_line#substitute#replace_pattern_visually
+			let string = s:hl_mark_begin . s:hl_mark_center . string . s:hl_mark_end
+		else
+			let string = s:hl_mark_begin . '\0' . s:hl_mark_center . string . s:hl_mark_end
+		endif
 	endif
 	let s:undo_flag = s:silent_substitute(range, pattern, string, flags)
 

--- a/doc/over.txt
+++ b/doc/over.txt
@@ -124,6 +124,26 @@ Default: >
     \	"\r" : '\\r',
     \}
 <
+g:over#command_line#substitute#replace_pattern_visually
+*g:over#command_line#substitute#replace_pattern_visually*
+  Instead of previewing the replacement next to the replaced pattern, it
+  visually replaces the pattern instead.
+Default:
+  Not enabled. To enable, set it to 1.
+Example: >
+  The wolf jumps over the sheep.
+       /\
+       || --- You want to replace 'wolf' with 'bear'.
+
+  The [wolf][bear] jumps over the sheep.
+       /\
+       || --- Here is how vim-over will show you the preview normally.
+
+  The [bear] jumps over the sheep.
+       /\
+       || --- Here is how vim-over will show you the preview with this
+              option enabled.
+<
 
 
 ==============================================================================


### PR DESCRIPTION
Fixes #56 

With the suggestion from [this Reddit comment](https://www.reddit.com/r/vim/comments/4bej4a/vimover_but_with_search_cleared/d18r6jg/).

![Demo](https://giant.gfycat.com/FriendlyFakeJapanesebeetle.gif)
[Demo](https://giant.gfycat.com/FriendlyFakeJapanesebeetle.webm)